### PR TITLE
Add updated Veinminer Enchantment ID

### DIFF
--- a/src/main/generated/resourcepacks/loot_rework/data/penchant/tags/enchantment/rare.json
+++ b/src/main/generated/resourcepacks/loot_rework/data/penchant/tags/enchantment/rare.json
@@ -13,6 +13,7 @@
     "minecraft:thorns",
     "minecraft:infinity",
     "minecraft:multishot",
-    "veinminer-enchantment:veinminer?"
+    "veinminer-enchantment:veinminer?",
+    "veinminer_enchantment:veinminer?"
   ]
 }


### PR DESCRIPTION
On the latest update for the Veinminer Enchantment Mod, they changed the namespace where the enchantment is located so it fits better with NeoForge requirements. This pull request adds the new ID and also keeps the old one incase someone is using an older version of the mod.


I have no way of playtesting this change so please if you can, tell me if theres any issues. Also my very first pull request so thats cool