### PR TITLE
Add updated Veinminer Enchantment ID (New)

### DIFF
--- a/src/client/java/archives/tater/penchant/datagen/LootEnchantmentTagGenerator.java
+++ b/src/client/java/archives/tater/penchant/datagen/LootEnchantmentTagGenerator.java
@@ -80,7 +80,7 @@ public class LootEnchantmentTagGenerator extends EnchantmentTagsProvider {
 
         tag(rare)
                 .addAll(RARE)
-                .addOptional(ResourceKey.create(Registries.ENCHANTMENT, Identifier.fromNamespaceAndPath("veinminer-enchantment", "veinminer")));
+                .addOptional(ResourceKey.create(Registries.ENCHANTMENT, Identifier.fromNamespaceAndPath("veinminer-enchantment", "veinminer")))
                 .addOptional(ResourceKey.create(Registries.ENCHANTMENT, Identifier.fromNamespaceAndPath("veinminer_enchantment", "veinminer")));
 
         tag(uncommon)

--- a/src/client/java/archives/tater/penchant/datagen/LootEnchantmentTagGenerator.java
+++ b/src/client/java/archives/tater/penchant/datagen/LootEnchantmentTagGenerator.java
@@ -81,6 +81,7 @@ public class LootEnchantmentTagGenerator extends EnchantmentTagsProvider {
         tag(rare)
                 .addAll(RARE)
                 .addOptional(ResourceKey.create(Registries.ENCHANTMENT, Identifier.fromNamespaceAndPath("veinminer-enchantment", "veinminer")));
+                .addOptional(ResourceKey.create(Registries.ENCHANTMENT, Identifier.fromNamespaceAndPath("veinminer_enchantment", "veinminer")));
 
         tag(uncommon)
                 .addAll(UNCOMMON)

--- a/src/main/generated/resourcepacks/loot_rework/data/penchant/tags/enchantment/rare.json
+++ b/src/main/generated/resourcepacks/loot_rework/data/penchant/tags/enchantment/rare.json
@@ -13,6 +13,7 @@
     "minecraft:thorns",
     "minecraft:infinity",
     "minecraft:multishot",
-    "veinminer-enchantment:veinminer?"
+    "veinminer-enchantment:veinminer?",
+    "veinminer_enchantment:veinminer?"
   ]
 }


### PR DESCRIPTION
On the latest update for the Veinminer Enchantment Mod, they changed the namespace where the enchantment is located so it fits better with NeoForge requirements. This pull request adds the new ID and also keeps the old one incase someone is using an older version of the mod.

I think I did everything but if I messed something up or missed something let me know.