### PR TITLE
Add missing translations for `randomized_librarians` data pack and `random_enchantment` tooltip

### DIFF
--- a/src/main/resources/assets/penchant/lang/ru_ru.json
+++ b/src/main/resources/assets/penchant/lang/ru_ru.json
@@ -29,6 +29,8 @@
   "dataPack.penchant.guaranteed_drops.description": "С мобов всегда будет выпадать зачарованное снаряжение",
   "dataPack.penchant.reduced_curses.name": "Меньше проклятий [Penchant]",
   "dataPack.penchant.reduced_curses.description": "Проклятия появляются только на снаряжении мобов",
+  "dataPack.penchant.randomized_librarians.name": "Случайные библиотекари [Penchant]",
+  "dataPack.penchant.randomized_librarians.description": "Библиотекари продают разную книгу каждый раз",
   "advancements.penchant.enchanted_bookshelf.title": "Исследования и разработки",
   "advancements.penchant.enchanted_bookshelf.description": "Разблокируйте зачарование, расположив зачарованную книгу рядом со столом зачарования",
   "advancements.penchant.all_enchantments.title": "Омнимантия",
@@ -39,6 +41,7 @@
   "advancements.penchant.babel.description": "Постройте библиотеку зачарования с более чем 300 книгами",
   "advancements.penchant.extract_enchantment.title": "Обратная разработка",
   "advancements.penchant.extract_enchantment.description": "Извлеките зачарования из найденного снаряжения",
-  "modmenu.descriptionTranslation.penchant": "Переработка заклинаний, направленная на повышение уровня заклинаний посредством их использования.",
-  "fml.menu.mods.info.description.penchant": "Переработка заклинаний, направленная на повышение уровня заклинаний посредством их использования."
+  "modmenu.descriptionTranslation.penchant": "Переработка зачарований, направленная на повышение уровня зачарований посредством их использования.",
+  "fml.menu.mods.info.description.penchant": "Переработка зачарований, направленная на повышение уровня зачарований посредством их использования.",
+  "penchant.tooltip.random_enchantment": "Случайное зачарование"
 }

--- a/src/main/resources/assets/penchant/lang/uk_ua.json
+++ b/src/main/resources/assets/penchant/lang/uk_ua.json
@@ -29,6 +29,8 @@
   "dataPack.penchant.guaranteed_drops.description": "З мобів завжди випадатиме зачароване спорядження",
   "dataPack.penchant.reduced_curses.name": "Менше проклять [Penchant]",
   "dataPack.penchant.reduced_curses.description": "Прокляття з'являються лише на спорядженні мобів",
+  "dataPack.penchant.randomized_librarians.name": "Випадкові бібліотекарі [Penchant]",
+  "dataPack.penchant.randomized_librarians.description": "Бібліотекарі продають різну книгу щоразу",
   "advancements.penchant.enchanted_bookshelf.title": "Дослідження та розроблення",
   "advancements.penchant.enchanted_bookshelf.description": "Розблокуйте зачарування, поклавши зачаровану книгу біля свого стола зачарування",
   "advancements.penchant.all_enchantments.title": "Омнімантія",
@@ -40,5 +42,6 @@
   "advancements.penchant.extract_enchantment.title": "Зворотне проєктування",
   "advancements.penchant.extract_enchantment.description": "Видобудьте зачарування зі знайденого спорядження",
   "modmenu.descriptionTranslation.penchant": "Переробка зачарувань, спрямована на підвищення Їхнього рівня шляхом використання.",
-  "fml.menu.mods.info.description.penchant": "Переробка зачарувань, спрямована на підвищення Їхнього рівня шляхом використання."
+  "fml.menu.mods.info.description.penchant": "Переробка зачарувань, спрямована на підвищення Їхнього рівня шляхом використання.",
+  "penchant.tooltip.random_enchantment": "Випадкове зачарування"
 }


### PR DESCRIPTION
Added missing localization strings that were present in `en_us.json` but absent from `ru_ru.json` and `uk_ua.json`:

- `dataPack.penchant.randomized_librarians.name`
- `dataPack.penchant.randomized_librarians.description`
- `penchant.tooltip.random_enchantment`

**Translations:**
| Key | `ru_ru` | `uk_ua` |
|---|---|---|
| `randomized_librarians.name` | Случайные библиотекари [Penchant] | Випадкові бібліотекарі [Penchant] |
| `randomized_librarians.description` | Библиотекари продают разную книгу каждый раз | Бібліотекарі продають різну книгу щоразу |
| `random_enchantment` | Случайное зачарование | Випадкове зачарування |

Follows existing naming conventions and terminology used across the mod's localization files.